### PR TITLE
Use sub claim for user ID instead of id in JWT

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -31,7 +31,6 @@ type API struct {
 
 type JWTClaims struct {
 	jwt.StandardClaims
-	ID     string   `json:"id"`
 	Email  string   `json:"email"`
 	Groups []string `json:"groups"`
 }
@@ -119,9 +118,9 @@ func (a *API) populateConfig(ctx context.Context, w http.ResponseWriter, r *http
 	}
 
 	claims := token.Claims.(*JWTClaims)
-	if claims.ID == "" {
-		log.Info("JWT token did not contain an id")
-		writeError(w, http.StatusBadRequest, "JWT Token must contain an id")
+	if claims.Subject == "" {
+		log.Info("JWT token did not contain a sub")
+		writeError(w, http.StatusBadRequest, "JWT Token must contain a sub")
 		return nil
 	}
 
@@ -134,7 +133,7 @@ func (a *API) populateConfig(ctx context.Context, w http.ResponseWriter, r *http
 	}
 	log = log.WithFields(logrus.Fields{
 		"is_admin": adminFlag,
-		"user_id":  claims.ID,
+		"user_id":  claims.Subject,
 	})
 	ctx = setAdminFlag(ctx, adminFlag)
 	ctx = setToken(ctx, token)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/jinzhu/gorm"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/netlify/gojoin/conf"
@@ -75,7 +75,7 @@ func TestTokenExtraction(t *testing.T) {
 	if assert.NotNil(t, token) {
 		assert.Nil(t, token.Claims.Valid())
 		outClaims := token.Claims.(*JWTClaims)
-		assert.Equal(t, "joker", outClaims.ID)
+		assert.Equal(t, "joker", outClaims.Subject)
 
 		foundAdmin := false
 		for _, g := range outClaims.Groups {
@@ -210,7 +210,9 @@ func testToken(t *testing.T, name, email, secret string, isAdmin bool) string {
 
 func testTokenWithGroups(t *testing.T, name, email, secret string, isAdmin bool, groups []string) string {
 	claims := &JWTClaims{
-		ID:    name,
+		StandardClaims: jwt.StandardClaims{
+			Subject: name,
+		},
 		Email: email,
 	}
 	claims.ExpiresAt = time.Now().Add(time.Hour).Unix()

--- a/api/subscriptions.go
+++ b/api/subscriptions.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/sirupsen/logrus"
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/guregu/kami"
 	"github.com/netlify/gojoin/models"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/square/go-jose.v1/json"
 )
 
@@ -48,17 +48,17 @@ func listSubs(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	db := getDB(ctx)
 
 	subs := []models.Subscription{}
-	if rsp := db.Where("user_id = ? ", claims.ID).Find(&subs); rsp.Error != nil {
+	if rsp := db.Where("user_id = ? ", claims.Subject).Find(&subs); rsp.Error != nil {
 		if rsp.RecordNotFound() {
-			notFoundError(w, "Found no records associated with user id %s", claims.ID)
+			notFoundError(w, "Found no records associated with user id %s", claims.Subject)
 		} else {
-			log.WithError(rsp.Error).Warnf("Failed to find records associated with %s", claims.ID)
+			log.WithError(rsp.Error).Warnf("Failed to find records associated with %s", claims.Subject)
 			writeError(w, http.StatusInternalServerError, "DB error while searching for subscriptions")
 		}
 		return
 	}
 
-	log.Debugf("Found %d subscriptions associated with id %s", len(subs), claims.ID)
+	log.Debugf("Found %d subscriptions associated with id %s", len(subs), claims.Subject)
 
 	response := &getAllResponse{
 		Subscriptions: subs,
@@ -96,7 +96,7 @@ func listSubs(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 func viewSub(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	subType := kami.Param(ctx, "type")
 	claims := getClaims(ctx)
-	sub, err := getSubscription(ctx, claims.ID, subType)
+	sub, err := getSubscription(ctx, claims.Subject, subType)
 	if err != nil {
 		sendJSON(w, err.Code, err)
 	}
@@ -111,7 +111,7 @@ func viewSub(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 func deleteSub(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	subType := kami.Param(ctx, "type")
 	claims := getClaims(ctx)
-	sub, err := getSubscription(ctx, claims.ID, subType)
+	sub, err := getSubscription(ctx, claims.Subject, subType)
 	if err != nil {
 		sendJSON(w, err.Code, err)
 	}
@@ -156,7 +156,7 @@ func createOrModSub(ctx context.Context, w http.ResponseWriter, r *http.Request)
 
 	// do we have a subscription already?
 	claims := getClaims(ctx)
-	sub, httpErr := getSubscription(ctx, claims.ID, subType)
+	sub, httpErr := getSubscription(ctx, claims.Subject, subType)
 	if httpErr != nil {
 		sendJSON(w, httpErr.Code, httpErr)
 		return
@@ -186,11 +186,11 @@ func createSub(ctx context.Context, subType string, payload *subscriptionRequest
 
 	// do we have a user?
 	user := &models.User{
-		ID: claims.ID,
+		ID: claims.Subject,
 	}
 	if rsp := db.Where(user).Find(user); rsp.Error != nil {
 		if rsp.RecordNotFound() {
-			remoteID, err := pp.createCustomer(claims.ID, claims.Email, payload.StripeKey)
+			remoteID, err := pp.createCustomer(claims.Subject, claims.Email, payload.StripeKey)
 			if err != nil {
 				return nil, httpError(http.StatusInternalServerError, "Failed to create new customer in stripe")
 			}


### PR DESCRIPTION
**- Summary**

`sub` is the standard claim for a unique identifer. We should be using that instead of a custom `id` claim.

**- Test plan**

Tests pass.

**- Description for the changelog**

Use `sub` instead of `id` for user ID claim.